### PR TITLE
Use Bigtop to detect $JAVA_HOME

### DIFF
--- a/kiji-rest/src/main/scripts/kiji-rest.initd
+++ b/kiji-rest/src/main/scripts/kiji-rest.initd
@@ -24,6 +24,13 @@
 # description: KijiREST Service
 #
 
+# Autodetect JAVA_HOME if not defined
+if [ -e /usr/libexec/bigtop-detect-javahome ]; then
+  . /usr/libexec/bigtop-detect-javahome
+elif [ -e /usr/lib/bigtop-utils/bigtop-detect-javahome ]; then
+  . /usr/lib/bigtop-utils/bigtop-detect-javahome
+fi
+
 RETVAL=0
 SLEEP_TIME=5
 


### PR DESCRIPTION
`service` clears most environment variables (see `man service`) so $JAVA_HOME is not set in
kiji-rest.initd.  And, because $JAVA_HOME isn't set, I can't run this program via `service`.

This sets $JAVA_HOME if Bigtop is present.
